### PR TITLE
Allow installation with composer 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">=5.2.4",
-    "composer/installers": "~1.0"
+    "composer/installers": ">=1.0"
 },
   "require-dev": {
     "brain/monkey": "1.4.2"


### PR DESCRIPTION
Those of us using composer 2.0 are unable to install this plugin due to the composer/installers dependency being constrained to a version unsupported by current release of composer 2.

Please change the composer/installers version constraint  to allow projects with a  composer.json depending on a ~2.0 version of the composer/installers package to install this package.

Another solution might be to remove the composer/installers dependency altogether as it's no longer required.

Thanks!
