### PR TITLE
Fix REST comments

### DIFF
--- a/disable-comments-mu.php
+++ b/disable-comments-mu.php
@@ -213,7 +213,7 @@ class Disable_Comments_MU {
 
 	public function disable_rest_API_comments($prepared_comment, $request)
 	{
-		return;
+		return array();
 	}
 
 	public function filter_existing_comments($comments, $post_id)


### PR DESCRIPTION
This filter need an array.
https://github.com/WordPress/wordpress-develop/blob/869b847bd392a92f2ae5b4d1c9c761b86c231990/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php#L697-L702
@alimuzzaman 